### PR TITLE
Jobooth execve transform

### DIFF
--- a/AuditEventProcessor.cpp
+++ b/AuditEventProcessor.cpp
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <iostream>
 #include <system_error>
+#include <unordered_set>
 
 #include <rapidjson/document.h>
 #include <rapidjson/stringbuffer.h>
@@ -40,6 +41,12 @@
 extern "C" {
 #include <dlfcn.h>
 }
+
+#include <linux/audit.h>
+#include <syscall.h>
+
+#define PROCESS_CREATE_RECORD_TYPE 4688
+#define PROCESS_CREATE_RECORD_NAME "PROC_CREATE"
 
 /*****************************************************************************
  * Dynamicly load needed libaudit symbols
@@ -122,13 +129,159 @@ void AuditEventProcessor::static_callback(void *au, dummy_enum_t cb_event_type, 
     processor->callback(au);
 }
 
+bool AuditEventProcessor::process_execve()
+{
+    static const std::unordered_set<std::string> execve_fields = { "arch", "syscall", "success", "exit", "items", "ppid", "pid", "auid", "uid", "gid", "euid", "suid", "fsuid", "egid", "sgid", "fsgid", "tty", "ses", "comm", "exe", "key", "name", "inode", "dev", "mode", "ouid", "ogid", "rdev", "nametype", "cwd", "cmdline" };
+
+    if (auparse_get_type(_state) != AUDIT_SYSCALL) {
+        return false;
+    }
+
+    const char *syscall = auparse_find_field(_state, "syscall");
+    auparse_first_field(_state);
+
+    if (syscall == nullptr || atoi(syscall) != SYS_execve) {
+        return false;
+    }
+
+    auto ret = _builder->BeginEvent(_current_event_sec, _current_event_msec, _current_event_serial, 1);
+    if (ret != 1) {
+        if (ret == Queue::CLOSED) {
+            throw std::runtime_error("Queue closed");
+        }
+        return false;
+    }
+
+    ret = _builder->BeginRecord(PROCESS_CREATE_RECORD_TYPE, PROCESS_CREATE_RECORD_NAME, "", execve_fields.size());
+    if (ret != 1) {
+        if (ret == Queue::CLOSED) {
+            throw std::runtime_error("Queue closed");
+        }
+        cancel_event();
+        return false;
+    }
+
+    do {
+        int record_type = auparse_get_type(_state);
+
+        switch (record_type) {
+            case AUDIT_SYSCALL: {
+                do {
+                    const char* field = auparse_get_field_name(_state);
+                    if (field != nullptr && execve_fields.count(std::string(field)) && !process_field(field)) {
+                        cancel_event();
+                        return false;
+                    }
+                } while (auparse_next_field(_state) == 1);
+                break;
+            }
+            case AUDIT_EXECVE: {
+                std::string commandline = "";
+                do {
+                    int number;
+                    const char* field = auparse_get_field_name(_state);
+
+                    if (sscanf(field, "a%d", &number) < 1) {
+                        continue;
+                    }
+
+                    if (!commandline.empty())
+                        commandline.push_back(' ');
+
+                    if (auparse_get_field_type(_state) == AUPARSE_TYPE_ESCAPED) {
+                        field = auparse_interpret_field(_state);
+
+                        commandline.push_back('"');
+                        for (const char *c = field; *c != '\0'; ++c) {
+                            switch (*c) {
+                                case '"':
+                                case '\\':
+                                case '$':
+                                case '`':
+                                    commandline.push_back('\\');
+                                default:
+                                    commandline.push_back(*c);
+                            }
+                        }
+                        commandline.push_back('"');
+                    }
+                    else {
+                        field = auparse_get_field_str(_state);
+                        commandline.append(field);
+                    }
+                } while (auparse_next_field(_state) == 1);
+
+                ret = _builder->AddField("cmdline", commandline.c_str(), NULL, FIELD_TYPE_UNCLASSIFIED);
+                if (ret != 1) {
+                    if (ret == Queue::CLOSED) {
+                        throw std::runtime_error("Queue closed");
+                    }
+                    cancel_event();
+                    return false;
+                }
+                break;
+            }
+            case AUDIT_CWD: {
+                const char* field = auparse_find_field(_state, "cwd");
+                if (field == nullptr || !process_field("cwd")) {
+                    break;
+                };
+                break;
+            }
+            case AUDIT_PATH: {
+                const char* field = auparse_find_field(_state, "item");
+                if (field == nullptr || strcmp(field, "0") != 0) {
+                    break;
+                }
+
+                auparse_first_field(_state);
+                do {
+                    field = auparse_get_field_name(_state);
+                    if (field != nullptr && execve_fields.count(field) && !process_field(field)) {
+                        cancel_event();
+                        return false;
+                    }
+                } while (auparse_next_field(_state) == 1);
+                break;
+            }
+            case AUDIT_PROCTITLE:
+            case AUDIT_EOE:
+                break;
+            case 0:
+                Logger::Warn("auparse_get_type() failed!");
+                break;
+            default:
+                Logger::Warn("Unexpected EXECVE record type - " + record_type);
+                break;
+        }
+    } while (auparse_next_record(_state) == 1);
+
+    if (_builder->GetFieldCount() != execve_fields.size()) {
+        cancel_event();
+        return false;
+    }
+
+    ret = _builder->EndRecord();
+    if (ret != 1) {
+        if (ret == Queue::CLOSED) {
+            throw std::runtime_error("Queue closed");
+        }
+        cancel_event();
+        return false;
+    }
+
+    end_event();
+    return true;
+}
+
 void AuditEventProcessor::callback(void *ptr)
 {
     assert(_state_ptr == ptr);
     assert(audit_msg_type_to_name != nullptr);
 
     // Process the event
-    _pid_found = false;
+    _pid = 0;
+    _ppid = 0;
     _event_flags = 0;
     const au_event_t *e = auparse_get_timestamp(_state);
     _current_event_sec = static_cast<uint64_t>(e->sec);
@@ -144,6 +297,10 @@ void AuditEventProcessor::callback(void *ptr)
 
     if (auparse_first_record(_state) != 1) {
         Logger::Warn("auparse_first_record() failed!");
+        return;
+    }
+
+    if (_num_records > 4 && process_execve()) {
         return;
     }
 
@@ -249,14 +406,12 @@ void AuditEventProcessor::cancel_event()
 inline bool NAME_EQUAL_PID(const char *name) {
     return *reinterpret_cast<const uint32_t*>(name) == 0x00646970;
 }
+inline bool NAME_EQUAL_PPID(const char *name) {
+    return *reinterpret_cast<const uint32_t*>(name) == 0x64697070 && name[4] == '\0';
+}
 
-bool AuditEventProcessor::process_field()
+bool AuditEventProcessor::process_field(const char *name_ptr)
 {
-    const char* name_ptr = auparse_get_field_name(_state);
-    if (name_ptr == nullptr) {
-        return false;
-    }
-
     const char* val_ptr = auparse_get_field_str(_state);
     if (val_ptr == nullptr) {
         return false;
@@ -271,11 +426,14 @@ bool AuditEventProcessor::process_field()
         case FIELD_TYPE_UNCLASSIFIED: {
             interp_ptr = auparse_interpret_field(_state);
 
-            if (!_pid_found && NAME_EQUAL_PID(name_ptr)) {
-                int64_t pid = atoll(val_ptr);
-                if (pid != 0) {
-                    _builder->SetEventPid(pid);
+            if (_pid == 0 && NAME_EQUAL_PID(name_ptr)) {
+                _pid = atoi(val_ptr);
+                if (_pid != 0) {
+                    _builder->SetEventPid(_pid);
                 }
+            }
+            else if (_ppid == 0 && NAME_EQUAL_PPID(name_ptr)) {
+                _ppid = atoi(val_ptr);
             }
 
             if (strcmp(val_ptr, interp_ptr) == 0) {
@@ -329,4 +487,13 @@ bool AuditEventProcessor::process_field()
         return false;
     }
     return true;
+}
+
+bool AuditEventProcessor::process_field()
+{
+    const char* name_ptr = auparse_get_field_name(_state);
+    if (name_ptr == nullptr) {
+        return false;
+    }
+    return process_field(name_ptr);
 }

--- a/AuditEventProcessor.cpp
+++ b/AuditEventProcessor.cpp
@@ -133,7 +133,7 @@ bool AuditEventProcessor::process_execve()
 {
     static const std::unordered_set<std::string> execve_fields = { "arch", "syscall", "success", "exit", "items", "ppid", "pid", "auid", "uid", "gid", "euid", "suid", "fsuid", "egid", "sgid", "fsgid", "tty", "ses", "comm", "exe", "key", "name", "inode", "dev", "mode", "ouid", "ogid", "rdev", "nametype", "cwd", "cmdline" };
 
-    if (auparse_get_type(_state) != AUDIT_SYSCALL) {
+    if (_num_records < 5 || auparse_get_type(_state) != AUDIT_SYSCALL) {
         return false;
     }
 
@@ -300,7 +300,7 @@ void AuditEventProcessor::callback(void *ptr)
         return;
     }
 
-    if (_num_records > 4 && process_execve()) {
+    if (process_execve()) {
         return;
     }
 

--- a/AuditEventProcessor.cpp
+++ b/AuditEventProcessor.cpp
@@ -133,7 +133,7 @@ bool AuditEventProcessor::process_execve()
 {
     static const std::unordered_set<std::string> execve_fields = { "arch", "syscall", "success", "exit", "items", "ppid", "pid", "auid", "uid", "gid", "euid", "suid", "fsuid", "egid", "sgid", "fsgid", "tty", "ses", "comm", "exe", "key", "name", "inode", "dev", "mode", "ouid", "ogid", "rdev", "nametype", "cwd", "cmdline" };
 
-    if (auparse_first_record(_state) != 1 || _num_records < 2 || auparse_get_type(_state) != AUDIT_SYSCALL) {
+    if (auparse_first_record(_state) != 1 || _num_records < 4 || auparse_get_type(_state) != AUDIT_SYSCALL) {
         return false;
     }
 
@@ -241,15 +241,11 @@ bool AuditEventProcessor::process_execve()
                 } while (auparse_next_field(_state) == 1);
                 break;
             }
-            case AUDIT_PROCTITLE:
-            case AUDIT_EOE:
-            case AUDIT_BPRM_FCAPS:
                 break;
             case 0:
                 Logger::Warn("auparse_get_type() failed!");
                 break;
             default:
-                Logger::Warn("Unexpected EXECVE record type - " + record_type);
                 break;
         }
     } while (auparse_next_record(_state) == 1);

--- a/AuditEventProcessor.h
+++ b/AuditEventProcessor.h
@@ -61,6 +61,7 @@ private:
     uint32_t _event_flags;
     pid_t _pid;
     pid_t _ppid;
+    std::string _cmdline;
 };
 
 #endif //AUOMS_AUDIT_EVENT_PROCESSOR_H

--- a/AuditEventProcessor.h
+++ b/AuditEventProcessor.h
@@ -21,6 +21,7 @@
 
 #include <string>
 #include <memory>
+#include <sys/types.h>
 
 typedef enum {DUMMY_ENUM} dummy_enum_t;
 
@@ -46,6 +47,8 @@ private:
     bool begin_event();
     void end_event();
     void cancel_event();
+    bool process_execve();
+    bool process_field(const char *name_ptr);
     bool process_field();
 
     std::shared_ptr<EventBuilder> _builder;
@@ -55,8 +58,9 @@ private:
     uint64_t _current_event_sec;
     uint32_t _current_event_msec;
     uint64_t _current_event_serial;
-    bool _pid_found;
     uint32_t _event_flags;
+    pid_t _pid;
+    pid_t _ppid;
 };
 
 #endif //AUOMS_AUDIT_EVENT_PROCESSOR_H

--- a/Event.cpp
+++ b/Event.cpp
@@ -406,6 +406,10 @@ int EventBuilder::AddField(const char *field_name, const char* raw_value, const 
         throw std::runtime_error("interp_value length exceeds limit");
     }
 
+    if (_field_idx >= _num_fields) {
+        throw std::runtime_error("field count exceeds allocated number");
+    }
+
     size_t size = _size+fsize;
     int ret = _allocator->Allocate(reinterpret_cast<void**>(&_data), size);
     if (ret != 1) {

--- a/Event.cpp
+++ b/Event.cpp
@@ -437,6 +437,10 @@ int EventBuilder::AddField(const char *field_name, const char* raw_value, const 
     return 1;
 }
 
+int EventBuilder::GetFieldCount() {
+    return _field_idx;
+}
+
 /*****************************************************************************
  ** EventRecordField
  *****************************************************************************/

--- a/Event.h
+++ b/Event.h
@@ -87,6 +87,7 @@ public:
     int BeginRecord(uint16_t record_type, const char* record_name, const char* record_text, uint16_t num_fields);
     int EndRecord();
     int AddField(const char *field_name, const char* raw_value, const char* interp_value, event_field_type_t field_type);
+    int GetFieldCount();
 
 private:
     std::shared_ptr<IEventBuilderAllocator> _allocator;


### PR DESCRIPTION
Adding initial correlation of syscall / execve / cwd / path records into single new PROC_CREATE record.

Currently this only creates one of these new record types on finding all of the required fields for this record in a single event. This falls back to the previous copying of the original records where incomplete.