### PR TITLE
shift 16 bits left the configured mask to fit filtering flags

### DIFF
--- a/OMSEventWriterConfig.cpp
+++ b/OMSEventWriterConfig.cpp
@@ -169,7 +169,7 @@ static std::unordered_map<std::string, config_set_func_t> _configSetters = {
                 if (mask > 0xFFFF) {
                     return false;
                 }
-                et_config.FilterFlagsMask = static_cast<uint32_t>(mask);
+                et_config.FilterFlagsMask = static_cast<uint32_t>(mask) << 16;
             }
             return true;
         }},


### PR DESCRIPTION
as the propagated event flags are shifted 16 bit and the mask is not it seems the right solution is to shift the mask the same way.