### PR TITLE
Remove null byte from end of escaped strings

### DIFF
--- a/StringUtils.cpp
+++ b/StringUtils.cpp
@@ -250,8 +250,7 @@ size_t bash_escape_string(std::string& out, const char* in, size_t in_len) {
     for(; ptr < end; ++ptr, ++size) {
         switch (char_category_codes[static_cast<uint8_t>(*ptr)]) {
             case 'Z':
-                ptr = end;
-                break;
+                goto endloop;
             case '-':
                 flags |= __BASH_QUOTE_NEEDED;
                 break;
@@ -269,6 +268,8 @@ size_t bash_escape_string(std::string& out, const char* in, size_t in_len) {
                 break;
         }
     }
+
+endloop:
 
     // String is empty, use '' to represent empty string on bash commandline
     if (size == 0) {


### PR DESCRIPTION
Remove null byte from end of escaped strings by preventing unwanted final size increment when breaking loop.