### PR TITLE
Fixed event blocking

### DIFF
--- a/RawEventProcessor.cpp
+++ b/RawEventProcessor.cpp
@@ -687,13 +687,18 @@ bool RawEventProcessor::process_syscall_event(const Event& event) {
     std::shared_ptr<ProcessTreeItem> p;
     std::string cmdline;
 
-    if (!_cmdline.empty()) {
+    if (!_syscall.empty() && _syscall == "execve") {
         p = _processTree->AddProcess(ProcessTreeSource_execve, _pid, _ppid, uid, gid, exe, _cmdline);
     } else if (!_syscall.empty()) {
         p = _processTree->GetInfoForPid(_pid);
     }
 
-    ret = _builder->AddField(SV_CONTAINERID, p->_containerid, nullptr, field_type_t::UNCLASSIFIED);
+    std::string containerid = "";
+    if (p) {
+        containerid = p->_containerid;
+    }
+
+    ret = _builder->AddField(SV_CONTAINERID, containerid, nullptr, field_type_t::UNCLASSIFIED);
     if (ret != 1) {
         if (ret == Queue::CLOSED) {
             throw std::runtime_error("Queue closed");

--- a/RawEventProcessor.cpp
+++ b/RawEventProcessor.cpp
@@ -687,7 +687,7 @@ bool RawEventProcessor::process_syscall_event(const Event& event) {
     std::shared_ptr<ProcessTreeItem> p;
     std::string cmdline;
 
-    if (!_syscall.empty() && _syscall == "execve") {
+    if (!_syscall.empty() && starts_with(_syscall, "execve")) {
         p = _processTree->AddProcess(ProcessTreeSource_execve, _pid, _ppid, uid, gid, exe, _cmdline);
     } else if (!_syscall.empty()) {
         p = _processTree->GetInfoForPid(_pid);


### PR DESCRIPTION
Two small fixes to RawEventProcessor.cpp:
* first fixes assumption that all process starts (execves) have a cmdline; they don't so use the _syscall var to determine if execve or not - slightly more expensive but far more accurate.
* second fixes assumption that ProcessTree::GetInfoForPid() will always return a valid pointer; it won't if the pid isn't in the tree and the proc entry cannot be opened (process already ended, for example).
