### PR TITLE
added optional ebpf _kern debugging

### DIFF
--- a/ebpf_telemetry/.gitignore
+++ b/ebpf_telemetry/.gitignore
@@ -1,1 +1,2 @@
 build
+.vscode

--- a/ebpf_telemetry/ebpf_loader/CMakeLists.txt
+++ b/ebpf_telemetry/ebpf_loader/CMakeLists.txt
@@ -38,7 +38,7 @@
 #    $ cd ..                                                                    #
 #    $ rm -rf build                                                             #
 #    $ mkdir build; cd build                                                    #
-#    $ cmake ..                                                                 #
+#    $ cmake ..  <-DDEBUG_K=On> : to print out kernel debugging to trace_pipe   #
 #    $ make                                                                     #
 #                                                                               #
 #################################################################################
@@ -62,6 +62,9 @@ set(LINUX_SRC "/usr/src/linux")
 
 include(ExternalProject)
 
+#Set option for Debug Outputs
+option(DEBUG_K "Enter debug mode" Off)
+
 #Fetch libbpf
 ExternalProject_Add(libbpf
     GIT_REPOSITORY https://github.com/libbpf/libbpf.git
@@ -76,6 +79,7 @@ set(libbpf_SOURCE_DIR ${CMAKE_BINARY_DIR}/ebpf_loader/libbpf/src/libbpf)
 
 # make ebpf_loader
 add_library(ebpf_loader SHARED ebpf_telemetry_loader.c)
+add_definitions("-fPIC")
 add_dependencies(ebpf_loader libbpf)
 target_link_libraries(ebpf_loader ${libbpf_SOURCE_DIR}/src/libbpf.a elf z)
 target_include_directories(ebpf_loader PUBLIC
@@ -135,6 +139,11 @@ set(CLANG_DEFINES -D __KERNEL__
                   -D __BPF_TRACING__
                   -D __TARGET_ARCH_x86
                   )
+if (DEBUG_K)
+    message("   Using DEBUG_K Option...")
+    list(APPEND CLANG_DEFINES -DDEBUG_K)
+endif()
+
 set(CLANG_INCLUDES -include "${LINUX_SRC}/include/linux/kconfig.h"
                    -include "${LINUX_SRC}/samples/bpf/asm_goto_workaround.h"
                    -I "${libbpf_SOURCE_DIR}/src"

--- a/ebpf_telemetry/ebpf_loader/ebpf_kern/ebpf_kern_common.h
+++ b/ebpf_telemetry/ebpf_loader/ebpf_kern/ebpf_kern_common.h
@@ -34,6 +34,17 @@
 #include <bpf_tracing.h>
 #include "../../event_defs.h"
 
+// debug tracing cant be found using:
+// #cat /sys/kernel/debug/tracing/trace_pipe
+
+#ifdef DEBUG_K
+#define BPF_PRINTK( format, ... ) \
+    char fmt[] = format; \
+    bpf_trace_printk(fmt, sizeof(fmt), ##__VA_ARGS__ ); 
+#else
+#define BPF_PRINTK ((void)0);
+#endif
+
 struct bpf_map_def SEC("maps") event_map = {
 	.type = BPF_MAP_TYPE_PERF_EVENT_ARRAY, //BPF_MAP_TYPE_HASH doesnt stack....
 	.key_size = sizeof(int),

--- a/ebpf_telemetry/event_defs.h
+++ b/ebpf_telemetry/event_defs.h
@@ -63,6 +63,7 @@ typedef struct e_rec {
     unsigned long int  code_bytes_start; //Always 0xdeadbeef = 3735928559
     unsigned int       version;
     unsigned long      bootns;
+    long int           status;
     unsigned long      syscall_id;
     unsigned long      a[4];
     unsigned int       pid;


### PR DESCRIPTION
I've added some optional debug outputs for the raw tracepoints kernel side. It exposes some conditions when memory reads fails:

```
# cat /sys/kernel/debug/tracing/trace_pipe 
           <...>-82333 [001] .... 1560170.741771: 0: ERROR, OPEN(257): returned -14
           <...>-82333 [001] .... 1560170.741860: 0: ERROR, sys_enter failed, exiting syscall 257
``` 
In this scenario I think it helps to have an `event->status` code than can be processed in `sys_exit` to drop incomplete events kernel side. 