### PR TITLE
fixed verifier complaint

### DIFF
--- a/ebpf_telemetry/azure-pipelines.yml
+++ b/ebpf_telemetry/azure-pipelines.yml
@@ -19,7 +19,7 @@ stages:
             cd ebpf_telemetry          
             rm -rf ./build
             mkdir ./build && cd build
-            cmake ..
+            cmake .. -DDEBUG_K=On -DSTOPLOOP=10
             make all
           displayName: CMake Build All
         - task: PublishBuildArtifacts@1

--- a/ebpf_telemetry/ebpf_loader/CMakeLists.txt
+++ b/ebpf_telemetry/ebpf_loader/CMakeLists.txt
@@ -62,7 +62,7 @@ set(LINUX_SRC "/usr/src/linux")
 
 include(ExternalProject)
 
-#Set option for Debug Outputs
+#Set option for Debug Outputs for eBPF programs
 option(DEBUG_K "Enter debug mode" Off)
 
 #Fetch libbpf
@@ -82,6 +82,12 @@ add_library(ebpf_loader SHARED ebpf_telemetry_loader.c)
 add_definitions("-fPIC")
 add_dependencies(ebpf_loader libbpf)
 target_link_libraries(ebpf_loader ${libbpf_SOURCE_DIR}/src/libbpf.a elf z)
+
+if (STOPLOOP)
+    message("setting STOPLOOP Count=${STOPLOOP}")
+    target_compile_definitions( ebpf_loader PUBLIC STOPLOOP=${STOPLOOP})
+endif()
+
 target_include_directories(ebpf_loader PUBLIC
                            "${PROJECT_BINARY_DIR}"
                            "${libbpf_SOURCE_DIR}/src"
@@ -140,7 +146,7 @@ set(CLANG_DEFINES -D __KERNEL__
                   -D __TARGET_ARCH_x86
                   )
 if (DEBUG_K)
-    message("   Using DEBUG_K Option...")
+    message("Using DEBUG_K Option...")
     list(APPEND CLANG_DEFINES -DDEBUG_K)
 endif()
 

--- a/ebpf_telemetry/ebpf_loader/ebpf_kern/ebpf_telemetry_kern_raw_tp.c
+++ b/ebpf_telemetry/ebpf_loader/ebpf_kern/ebpf_telemetry_kern_raw_tp.c
@@ -134,7 +134,7 @@ static inline bool deref_filepath_into(char *dest, void *base, unsigned int *ref
         // check if current dentry name is valid
         if (dlen > 0) {
             // copy the temporary copy to the first half of our temporary storage, building it backwards from the middle of it
-            dlen = bpf_probe_read_str(&temp[(PATH_MAX - size - dlen) & (PATH_MAX - 1)], dlen, &temp[PATH_MAX]);
+            dlen = bpf_probe_read_str(&temp[(PATH_MAX - size - dlen) & (PATH_MAX - 1)], PATH_MAX, &temp[PATH_MAX]);
             if (dlen <= 0)
                 return false;
             if (size > 0)

--- a/ebpf_telemetry/ebpf_loader/ebpf_telemetry_loader.c
+++ b/ebpf_telemetry/ebpf_loader/ebpf_telemetry_loader.c
@@ -40,6 +40,12 @@
 #define KERN_TRACEPOINT_OBJ "ebpf_loader/ebpf_telemetry_kern_tp.o"
 #define KERN_RAW_TRACEPOINT_OBJ "ebpf_loader/ebpf_telemetry_kern_raw_tp.o"
 
+#ifndef STOPLOOP
+    #define STOPLOOP 0
+#endif
+
+static unsigned int isTesting       = STOPLOOP;
+
 static int    event_map_fd          = 0;
 static int    config_map_fd         = 0;
 static struct utsname     uname_s   = { 0 };
@@ -369,7 +375,9 @@ int ebpf_telemetry_start(void (*event_cb)(void *ctx, int cpu, void *data, __u32 
 
     int i = 0;
     while ((ret = perf_buffer__poll(pb, 1000)) >= 0 ) {
-//        if (i++ > 10) break;
+        if (isTesting){
+            if (i++ > STOPLOOP) break;
+        }
     }
 
     ebpf_telemetry_close_all();


### PR DESCRIPTION
I was getting the following errors on load. Looks  like the verifier for `5.3.0-1034-azure` was convinced that `dlen` could somehow be negative, despite the checks. Using a fixed length constant size seems to fix it. 
```
7123: (79) r3 = *(u64 *)(r10 -160)
7124: (85) call bpf_probe_read_str#45
R2 min value is negative, either use unsigned or 'var &= const'
```

Other than that there is some small cleanup for terminating the loop. This might be helpful for cross platform deployment testing