### PR TITLE
Reduce ProcessTree memory consumtion

### DIFF
--- a/ProcessInfo.h
+++ b/ProcessInfo.h
@@ -27,13 +27,12 @@ class ProcessInfo {
 public:
     ~ProcessInfo();
 
-    static std::unique_ptr<ProcessInfo> Open();
-    static std::unique_ptr<ProcessInfo> Open(int pid);
+    static std::unique_ptr<ProcessInfo> Open(int cmdline_size_limit);
+    static std::unique_ptr<ProcessInfo> Open(int pid, int cmdline_size_limit);
 
     bool next();
 
     void format_cmdline(std::string& str);
-    bool get_arg1(std::string& str);
 
     inline int pid()   { return _pid; }
     inline int ppid()  { return _ppid; }
@@ -58,7 +57,7 @@ public:
     inline bool is_cmdline_truncated() { return _cmdline_truncated; }
 
 private:
-    explicit ProcessInfo(void* dp);
+    explicit ProcessInfo(void* dp, int cmdline_size_limit);
 
     bool parse_stat();
     bool parse_status();
@@ -67,7 +66,7 @@ private:
     void clear();
 
     void* _dp;
-
+    int _cmdline_size_limit;
     time_t _boot_time;
 
     int _pid;

--- a/RawEventProcessor.cpp
+++ b/RawEventProcessor.cpp
@@ -898,7 +898,7 @@ void RawEventProcessor::DoProcessInventory() {
         return;
     }
 
-    auto pinfo = ProcessInfo::Open();
+    auto pinfo = ProcessInfo::Open(64*1024);
     if (!pinfo) {
         Logger::Error("Failed to open '/proc': %s", strerror(errno));
         return;


### PR DESCRIPTION
- Limit cmdline size to 1024 in ProcesTree entries
- Increased clean frequency from every 60 seconds to every 5 seconds
- Fix ProcessTree::Clean() so that it can detect exited processes
  even if an exit event was not received via pnotify