### PR TITLE
Fix compilation on AzureLinux and allow running in container

### DIFF
--- a/AuomsConfig.cpp
+++ b/AuomsConfig.cpp
@@ -46,6 +46,7 @@ std::string AuomsConfig::KEY_USE_SYSLOG = "use_syslog";
 std::string AuomsConfig::KEY_DISABLE_CGROUPS = "disable_cgroups";
 std::string AuomsConfig::KEY_DISABLE_EVENT_FILTERING = "disable_event_filtering";
 std::string AuomsConfig::KEY_DEFAULT_EVENT_PRIORITY = "default_event_priority";
+std::string AuomsConfig::KEY_PROC_PATH = "proc_path";
 
 std::unique_ptr<AuomsConfig> AuomsConfig::_instance;
 std::once_flag AuomsConfig::_initFlag;
@@ -65,6 +66,9 @@ AuomsConfig::Load(const std::string& path) {
     }
     if (HasKey(KEY_DATA_DIR)) {
         _data_dir = GetString(KEY_DATA_DIR);
+    }
+    if (HasKey(KEY_PROC_PATH)) {
+        _proc_path = GetString(KEY_PROC_PATH);
     }
     if (HasKey(KEY_RUN_DIR)) {
         _run_dir = GetString(KEY_RUN_DIR);
@@ -346,6 +350,12 @@ const std::string&
 AuomsConfig::GetOutconfDir() const {
     std::shared_lock<std::shared_mutex> lock(_mutex);
     return _outconf_dir;  
+}
+
+const std::string&
+AuomsConfig::GetProcPath() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _proc_path;
 }
 
 long

--- a/AuomsConfig.cpp
+++ b/AuomsConfig.cpp
@@ -1,0 +1,361 @@
+/*
+    microsoft-oms-auditd-plugin
+
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "AuomsConfig.h"
+#include "CPULimits.h"
+
+std::string AuomsConfig::KEY_OUTCONF_DIR = "outconf_dir";
+std::string AuomsConfig::KEY_RULES_DIR = "rules_dir";
+std::string AuomsConfig::KEY_REDACT_DIR = "redact_dir";
+std::string AuomsConfig::KEY_DATA_DIR = "data_dir";
+std::string AuomsConfig::KEY_RUN_DIR = "run_dir";
+std::string AuomsConfig::KEY_AUDITD_PATH = "auditd_path";
+std::string AuomsConfig::KEY_COLLECTOR_PATH = "collector_path";
+std::string AuomsConfig::KEY_COLLECTOR_CONFIG_PATH = "collector_config_path";
+std::string AuomsConfig::KEY_BACKLOG_LIMIT = "backlog_limit";
+std::string AuomsConfig::KEY_BACKLOG_WAIT_TIME = "backlog_wait_time";
+std::string AuomsConfig::KEY_INPUT_SOCKET_PATH = "input_socket_path";
+std::string AuomsConfig::KEY_STATUS_SOCKET_PATH = "status_socket_path";
+std::string AuomsConfig::KEY_SAVE_DIR = "save_dir";
+std::string AuomsConfig::KEY_QUEUE_DIR = "queue_dir";
+std::string AuomsConfig::KEY_RSS_LIMIT = "rss_limit";
+std::string AuomsConfig::KEY_RSS_PCT_LIMIT = "rss_pct_limit";
+std::string AuomsConfig::KEY_VIRT_LIMIT = "virt_limit";
+std::string AuomsConfig::KEY_NUM_PRIORITIES = "queue_num_priorities";
+std::string AuomsConfig::KEY_MAX_FILE_DATA_SIZE = "queue_max_file_data_size";
+std::string AuomsConfig::KEY_MAX_UNSAVED_FILES = "queue_max_unsaved_files";
+std::string AuomsConfig::KEY_MAX_FS_BYTES = "queue_max_fs_bytes";
+std::string AuomsConfig::KEY_MAX_FS_PCT = "queue_max_fs_pct";
+std::string AuomsConfig::KEY_MIN_FS_FREE_PCT = "queue_min_fs_free_pct";
+std::string AuomsConfig::KEY_SAVE_DELAY = "queue_save_delay";
+std::string AuomsConfig::KEY_LOCK_FILE = "lock_file";
+std::string AuomsConfig::KEY_USE_SYSLOG = "use_syslog";
+std::string AuomsConfig::KEY_DISABLE_CGROUPS = "disable_cgroups";
+std::string AuomsConfig::KEY_DISABLE_EVENT_FILTERING = "disable_event_filtering";
+std::string AuomsConfig::KEY_DEFAULT_EVENT_PRIORITY = "default_event_priority";
+
+std::unique_ptr<AuomsConfig> AuomsConfig::_instance;
+std::once_flag AuomsConfig::_initFlag;
+
+void
+AuomsConfig::Load(const std::string& path) {
+    Config::Load(path);
+
+    if (HasKey(KEY_OUTCONF_DIR)) {
+        _outconf_dir = GetString(KEY_OUTCONF_DIR);
+    }
+    if (HasKey(KEY_RULES_DIR)) {
+        _rules_dir = GetString(KEY_RULES_DIR);
+    }
+    if (HasKey(KEY_REDACT_DIR)) {
+        _redact_dir = GetString(KEY_REDACT_DIR);
+    }
+    if (HasKey(KEY_DATA_DIR)) {
+        _data_dir = GetString(KEY_DATA_DIR);
+    }
+    if (HasKey(KEY_RUN_DIR)) {
+        _run_dir = GetString(KEY_RUN_DIR);
+    }
+    if (HasKey(KEY_AUDITD_PATH)) {
+        _auditd_path = GetString(KEY_AUDITD_PATH);
+    }
+    if (HasKey(KEY_COLLECTOR_PATH)) {
+        _collector_path = GetString(KEY_COLLECTOR_PATH);
+    }
+    if (HasKey(KEY_COLLECTOR_CONFIG_PATH)) {
+        _collector_config_path = GetString(KEY_COLLECTOR_CONFIG_PATH);
+    }
+    if (HasKey(KEY_BACKLOG_LIMIT)) {
+        _backlog_limit = static_cast<uint32_t>(GetUint64(KEY_BACKLOG_LIMIT));
+    }
+    if (HasKey(KEY_BACKLOG_WAIT_TIME)) {
+        _backlog_wait_time = static_cast<uint32_t>(
+                                GetUint64(KEY_BACKLOG_WAIT_TIME)
+                                );
+    }
+    if (HasKey(KEY_INPUT_SOCKET_PATH)) {
+        _input_socket_path = GetString(KEY_INPUT_SOCKET_PATH);
+    } else {
+        _input_socket_path = _run_dir + "/input.socket";
+    }
+    if (HasKey(KEY_STATUS_SOCKET_PATH)) {
+        _status_socket_path = GetString(KEY_STATUS_SOCKET_PATH);
+    } else {
+        _status_socket_path = _run_dir + "/status.socket";
+    }
+    if (HasKey(KEY_SAVE_DIR)) {
+        _save_dir = GetString(KEY_SAVE_DIR);
+    } else {
+        _save_dir = _data_dir + "/save";
+    }
+    if (HasKey(KEY_QUEUE_DIR)) {
+        _queue_dir = GetString(KEY_QUEUE_DIR);
+    } else {
+        _queue_dir = _data_dir + "/queue";
+    }
+    if (HasKey(KEY_RSS_LIMIT)) {
+        _rss_limit = GetUint64(KEY_RSS_LIMIT);
+    }
+    if (HasKey(KEY_RSS_PCT_LIMIT)) {
+        _rss_pct_limit = GetDouble(KEY_RSS_PCT_LIMIT);
+    }
+    if (HasKey(KEY_VIRT_LIMIT)) {
+        _virt_limit = GetUint64(KEY_VIRT_LIMIT);
+    }
+    if (HasKey(KEY_NUM_PRIORITIES)) {
+        _num_priorities = GetUint64(KEY_NUM_PRIORITIES);
+    }
+    if (HasKey(KEY_MAX_FILE_DATA_SIZE)) {
+        _max_file_data_size = GetUint64(KEY_MAX_FILE_DATA_SIZE);
+    }
+    if (HasKey(KEY_MAX_UNSAVED_FILES)) {
+        _max_unsaved_files = GetUint64(KEY_MAX_UNSAVED_FILES);
+    }
+    if (HasKey(KEY_MAX_FS_BYTES)) {
+        _max_fs_bytes = GetUint64(KEY_MAX_FS_BYTES);
+    }
+    if (HasKey(KEY_MAX_FS_PCT)) {
+        _max_fs_pct = GetDouble(KEY_MAX_FS_PCT);
+    }
+    if (HasKey(KEY_MIN_FS_FREE_PCT)) {
+        _min_fs_free_pct = GetDouble(KEY_MIN_FS_FREE_PCT);
+    }
+    if (HasKey(KEY_SAVE_DELAY)) {
+        _save_delay = GetUint64(KEY_SAVE_DELAY);
+    }
+    if (HasKey(KEY_LOCK_FILE)) {
+        _lock_file = GetString(KEY_LOCK_FILE);
+    } else {
+        _lock_file = _data_dir + "/auoms.lock";
+    }
+    if (HasKey(KEY_USE_SYSLOG)) {
+        _useSyslog = GetBool(KEY_USE_SYSLOG);
+    }
+    if (HasKey(KEY_DISABLE_CGROUPS)) {
+        _disableCGroups = GetBool(KEY_DISABLE_CGROUPS);
+    }
+    // Set cgroup defaults
+    if (!HasKey(CPU_SOFT_LIMIT_NAME)) {
+        SetString(CPU_SOFT_LIMIT_NAME, "5");
+    }
+    if (!HasKey(CPU_HARD_LIMIT_NAME)) {
+        SetString(CPU_HARD_LIMIT_NAME, "25");
+    }
+    if (HasKey(KEY_DISABLE_EVENT_FILTERING)) {
+        _disableEventFiltering = GetBool(KEY_DISABLE_EVENT_FILTERING);
+    }
+    // Set EventPrioritizer defaults
+    if (!HasKey("event_priority_by_syscall")) {
+        SetString(
+            "event_priority_by_syscall",
+            R"json({"execve":2,"execveat":2,"*":3})json"
+        );
+    }
+    if (!HasKey("event_priority_by_record_type")) {
+        SetString(
+            "event_priority_by_record_type",
+            R"json({"AUOMS_EXECVE":2,"AUOMS_SYSCALL":3,"AUOMS_PROCESS_INVENTORY":1})json"
+        );
+    }
+    if (!HasKey("event_priority_by_record_type_category")) {
+        SetString(
+            "event_priority_by_record_type_category",
+            R"json({"AUOMS_MSG":0, "USER_MSG":1,"SELINUX":1,"APPARMOR":1})json"
+        );
+    }
+    if (HasKey(KEY_DEFAULT_EVENT_PRIORITY)) {
+        _defaultEventPriority = static_cast<uint16_t>(
+                                GetUint64(KEY_DEFAULT_EVENT_PRIORITY)
+                            );
+    }
+    if (_defaultEventPriority > _num_priorities-1) {
+        _defaultEventPriority = _num_priorities-1;
+    }
+}
+
+bool
+AuomsConfig::IsNetlinkOnly() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _isNetlinkOnly;
+}
+
+void
+AuomsConfig::SetNetlinkOnly(const bool& value) {
+    std::unique_lock<std::shared_mutex> lock(_mutex);
+    _isNetlinkOnly = value;
+}
+
+const std::string&
+AuomsConfig::GetQueueDir() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _queue_dir;
+}
+
+bool
+AuomsConfig::UseSyslog() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _useSyslog;
+}
+
+int
+AuomsConfig::GetDefaultEventPriority() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _defaultEventPriority;
+}
+
+const std::string&
+AuomsConfig::GetSaveDirectory() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _save_dir;
+}
+
+const std::string&
+AuomsConfig::GetLockFile() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _lock_file; 
+}
+
+bool
+AuomsConfig::DisableCGroups() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _disableCGroups;
+}
+
+int
+AuomsConfig::GetNumberOfEventPriorities() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _num_priorities; 
+}
+
+size_t
+AuomsConfig::GetMaxFileDataSize() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _max_file_data_size;
+}
+
+size_t
+AuomsConfig::GetMaxUnsavedFiles() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _max_unsaved_files;
+}
+
+size_t
+AuomsConfig::GetMaxFsBytes() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _max_fs_bytes;
+}
+
+double
+AuomsConfig::GetMaxFsPercentage() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _max_fs_pct;
+}
+
+double
+AuomsConfig::GetMinFsFreePercentage() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _min_fs_free_pct;
+}
+
+const std::string&
+AuomsConfig::GetStatusSocketPath() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _status_socket_path;
+}
+
+const std::string&
+AuomsConfig::GetRedactDir() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _redact_dir;
+}
+
+const std::string&
+AuomsConfig::GetInputSocketPath() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _input_socket_path;
+}
+
+uint64_t
+AuomsConfig::GetRSSLimit() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _rss_limit;
+}
+
+uint64_t
+AuomsConfig::GetVirtLimit() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _virt_limit;
+}
+
+double
+AuomsConfig::GetRSSPercentageLimit() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _rss_pct_limit;
+}
+
+const std::string&
+AuomsConfig::GetAuditdPath() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _auditd_path;
+}
+
+const std::string&
+AuomsConfig::GetCollectorPath() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _collector_path;
+}
+
+const std::string&
+AuomsConfig::GetCollectorConfigPath() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _collector_config_path;
+}
+
+const std::string&
+AuomsConfig::GetRulesDir() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _rules_dir; 
+}
+
+uint32_t
+AuomsConfig::GetBacklogLimit() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _backlog_limit;
+}
+
+uint32_t
+AuomsConfig::GetBacklogWaitTime() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _backlog_wait_time;
+}
+
+const std::string&
+AuomsConfig::GetOutconfDir() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _outconf_dir;  
+}
+
+long
+AuomsConfig::GetSaveDelay() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _save_delay;
+}
+
+bool
+AuomsConfig::DisableEventFiltering() const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    return _disableEventFiltering;
+}

--- a/AuomsConfig.h
+++ b/AuomsConfig.h
@@ -66,6 +66,7 @@ public:
     const std::string& GetCollectorConfigPath() const;
     const std::string& GetRulesDir() const;
     const std::string& GetOutconfDir() const;
+    const std::string& GetProcPath() const;
 
     uint64_t GetRSSLimit() const;
     uint64_t GetVirtLimit() const;
@@ -91,6 +92,7 @@ private:
     std::string _rules_dir = AUOMS_RULES_DIR;
     std::string _redact_dir = AUOMS_REDACT_DIR;
     std::string _data_dir = AUOMS_DATA_DIR;
+    std::string _proc_path = "/proc";
     std::string _run_dir = AUOMS_RUN_DIR;
     std::string _input_socket_path;
     std::string _status_socket_path;
@@ -152,4 +154,5 @@ private:
     static std::string KEY_DISABLE_CGROUPS;
     static std::string KEY_DISABLE_EVENT_FILTERING;
     static std::string KEY_DEFAULT_EVENT_PRIORITY;
+    static std::string KEY_PROC_PATH;
 };

--- a/AuomsConfig.h
+++ b/AuomsConfig.h
@@ -1,0 +1,155 @@
+/*
+    microsoft-oms-auditd-plugin
+
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Config.h"
+#include "env_config.h"
+
+#include <memory>
+#include <shared_mutex>
+#include <mutex>
+
+class AuomsConfig : public Config {
+public:
+    // Delete copy constructor and assignment operator
+    AuomsConfig(const AuomsConfig&) = delete;
+    AuomsConfig& operator=(const AuomsConfig&) = delete;
+
+    static AuomsConfig& GetInstance() {
+        std::call_once(_initFlag, []() {
+            _instance.reset(new AuomsConfig());
+        });
+        return *_instance;
+    }
+
+    virtual void Load(const std::string& path);
+
+    bool IsNetlinkOnly() const;
+    void SetNetlinkOnly(const bool& value);
+
+    const std::string& GetQueueDir() const;
+
+    bool UseSyslog() const;
+
+    int GetDefaultEventPriority() const;
+
+    const std::string& GetSaveDirectory() const;
+
+    const std::string& GetLockFile() const;
+
+    bool DisableCGroups() const;
+
+    int GetNumberOfEventPriorities() const;
+    size_t GetMaxFileDataSize() const;
+    size_t GetMaxUnsavedFiles() const;
+    size_t GetMaxFsBytes() const;
+    double GetMaxFsPercentage() const;
+    double GetMinFsFreePercentage() const;
+
+    const std::string& GetInputSocketPath() const;
+    const std::string& GetStatusSocketPath() const;
+    const std::string& GetRedactDir() const;
+    const std::string& GetAuditdPath() const;
+    const std::string& GetCollectorPath() const;
+    const std::string& GetCollectorConfigPath() const;
+    const std::string& GetRulesDir() const;
+    const std::string& GetOutconfDir() const;
+
+    uint64_t GetRSSLimit() const;
+    uint64_t GetVirtLimit() const;
+    double GetRSSPercentageLimit() const;
+
+    uint32_t GetBacklogLimit() const;
+    uint32_t GetBacklogWaitTime() const;
+
+    long GetSaveDelay() const;
+
+    bool DisableEventFiltering() const;
+
+private:
+    AuomsConfig() = default;
+
+    mutable std::shared_mutex _mutex;
+
+    std::string _auditd_path = AUDITD_BIN;
+    std::string _collector_path = AUOMSCOLLECT_EXE;
+    std::string _collector_config_path = "";
+
+    std::string _outconf_dir = AUOMS_OUTCONF_DIR;
+    std::string _rules_dir = AUOMS_RULES_DIR;
+    std::string _redact_dir = AUOMS_REDACT_DIR;
+    std::string _data_dir = AUOMS_DATA_DIR;
+    std::string _run_dir = AUOMS_RUN_DIR;
+    std::string _input_socket_path;
+    std::string _status_socket_path;
+    std::string _save_dir;
+    std::string _queue_dir;
+    std::string _lock_file;
+
+    uint32_t _backlog_limit = 10240;
+    uint32_t _backlog_wait_time = 1;
+
+    uint64_t _rss_limit = 1024L*1024L*1024L;
+    uint64_t _virt_limit = 4096L*1024L*1024L;
+    double _rss_pct_limit = 5;
+
+    int _num_priorities = 8;
+    size_t _max_file_data_size = 1024*1024;
+    size_t _max_unsaved_files = 128;
+    size_t _max_fs_bytes = 1024*1024*1024;
+    double _max_fs_pct = 10;
+    double _min_fs_free_pct = 5;
+    long _save_delay = 250;
+
+    bool _isNetlinkOnly = false;
+    bool _useSyslog = true;
+    bool _disableCGroups = false;
+    bool _disableEventFiltering = false;
+
+    int _defaultEventPriority = 4;
+
+    static std::unique_ptr<AuomsConfig> _instance;
+    static std::once_flag _initFlag;
+
+    static std::string KEY_OUTCONF_DIR;
+    static std::string KEY_RULES_DIR;
+    static std::string KEY_REDACT_DIR;
+    static std::string KEY_DATA_DIR;
+    static std::string KEY_RUN_DIR;
+    static std::string KEY_AUDITD_PATH;
+    static std::string KEY_COLLECTOR_PATH;
+    static std::string KEY_COLLECTOR_CONFIG_PATH;
+    static std::string KEY_BACKLOG_LIMIT;
+    static std::string KEY_BACKLOG_WAIT_TIME;
+    static std::string KEY_INPUT_SOCKET_PATH;
+    static std::string KEY_STATUS_SOCKET_PATH;
+    static std::string KEY_SAVE_DIR;
+    static std::string KEY_QUEUE_DIR;
+    static std::string KEY_RSS_LIMIT;
+    static std::string KEY_RSS_PCT_LIMIT;
+    static std::string KEY_VIRT_LIMIT;
+    static std::string KEY_NUM_PRIORITIES;
+    static std::string KEY_MAX_FILE_DATA_SIZE;
+    static std::string KEY_MAX_UNSAVED_FILES;
+    static std::string KEY_MAX_FS_BYTES;
+    static std::string KEY_MAX_FS_PCT;
+    static std::string KEY_MIN_FS_FREE_PCT;
+    static std::string KEY_SAVE_DELAY;
+    static std::string KEY_LOCK_FILE;
+    static std::string KEY_USE_SYSLOG;
+    static std::string KEY_DISABLE_CGROUPS;
+    static std::string KEY_DISABLE_EVENT_FILTERING;
+    static std::string KEY_DEFAULT_EVENT_PRIORITY;
+};

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ add_executable(auoms
         env_config.h
         auoms.cpp
         auoms_version.h
+        AuomsConfig.cpp
         IO.cpp
         Event.cpp
         EventPrioritizer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ add_executable(auoms
         CollectionMonitor.cpp
         Netlink.cpp
         NetlinkAudit.cpp
+        NetlinkCollectionMonitor.cpp
         TranslateArch.cpp
         TranslateSyscall.cpp
         TranslateRecordType.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(auomscollect
         env_config.h
         auoms_version.h
         auomscollect.cpp
+        AuomsConfig.cpp
         IO.cpp
         Event.cpp
         EventPrioritizer.cpp
@@ -422,6 +423,7 @@ add_test(String ${CMAKE_BINARY_DIR}/StringTests --log_sink=StringTests.log --rep
 add_executable(EventProcessorTests
         auoms_version.h
         EventProcessorTests.cpp
+        AuomsConfig.cpp
         Event.cpp
         RawEventProcessor.cpp
         RawEventAccumulator.cpp
@@ -467,6 +469,7 @@ add_test(EventProcessor ${CMAKE_BINARY_DIR}/EventProcessorTests --log_sink=Event
 add_executable(ProcessInfoTests
     auoms_version.h
     ProcessInfoTests.cpp
+    AuomsConfig.cpp
     Event.cpp
     Signals.cpp
     Logger.cpp
@@ -497,6 +500,7 @@ add_test(NAME ProcessInfoTests COMMAND ProcessInfoTests)
 add_executable(ProcessTreeTests
         auoms_version.h
         ProcessTreeTests.cpp
+        AuomsConfig.cpp
         Event.cpp
         Signals.cpp
         Logger.cpp

--- a/ICollectionMonitor.h
+++ b/ICollectionMonitor.h
@@ -1,0 +1,28 @@
+/*
+    microsoft-oms-auditd-plugin
+
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+
+    MIT License
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ""Software""), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef __ICOLLECTIONMONITOR_H
+#define __ICOLLECTIONMONITOR_H
+
+#include "RunBase.h"
+
+class ICollectionMonitor : public RunBase {
+protected:
+    void run() override = 0;
+    void on_stop() override = 0;
+};
+
+#endif /* __ICOLLECTIONMONITOR_H */

--- a/NetlinkCollectionMonitor.h
+++ b/NetlinkCollectionMonitor.h
@@ -14,8 +14,8 @@
     THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#ifndef AUOMS_COLLECTIONMONITOR_H
-#define AUOMS_COLLECTIONMONITOR_H
+#ifndef NETLINK_COLLECTIONMONITOR_H
+#define NETLINK_COLLECTIONMONITOR_H
 
 #include "ICollectionMonitor.h"
 #include "Netlink.h"
@@ -25,25 +25,42 @@
 #include <chrono>
 #include <set>
 
-class CollectionMonitor: public ICollectionMonitor {
+class NetlinkCollectionMonitor : public ICollectionMonitor {
 public:
     static constexpr int COLLECTOR_RESTART_WINDOW = 30;
     static constexpr int MAX_COLLECTOR_RESTARTS = 15; // The maximum times the collector will be restarted within COLLECTOR_RESTART_WINDOW seconds before restarts are disabled.
 
-    CollectionMonitor(std::shared_ptr<PriorityQueue> queue,
-                      const std::string& auditd_path,
-                      const std::string& collector_path,
-                      const std::string& collector_config_path)
-            : _builder(std::make_shared<EventQueue>(std::move(queue)), nullptr),
-              _auditd_path(auditd_path), _collector_path(collector_path), _collector_config_path(collector_config_path),
-              _collector(collector_path, collector_args(collector_config_path), Cmd::PIPE_STDIN), _audit_pid(0), _pause_collector_check(false), _pause_time(), _last_audit_pid_report(), _collector_restarts() {}
-
+    NetlinkCollectionMonitor(
+        std::shared_ptr<PriorityQueue> queue,
+        const std::string& collector_path,
+        const std::string& collector_config_path)
+    :   _builder(std::make_shared<EventQueue>(std::move(queue)), nullptr),
+        _collector_path(collector_path),
+        _collector_config_path(collector_config_path),
+        _collector(
+            collector_path,
+            collector_args(collector_config_path),
+            Cmd::PIPE_STDIN
+        ),
+        _pause_collector_check(false),
+        _pause_time(),
+        _last_audit_pid_report(),
+        _collector_restarts() {
+        }
 protected:
     void run() override;
     void on_stop() override;
-
 private:
-    std::vector<std::string> collector_args(const std::string& collector_config_path) {
+    // Return true if child is alive, false if not. If wait is true and child is alive, will wait forever for child to exit.
+    bool check_child(bool wait);
+    void start_collector();
+    void signal_collector(int signal);
+    bool is_collector_alive();
+    void report_proc_exit_status(Cmd& cmd);
+
+    std::vector<std::string> collector_args(
+        const std::string& collector_config_path
+    ) {
         std::vector<std::string> args;
         args.emplace_back("-n");
         if (!collector_config_path.empty()) {
@@ -53,30 +70,15 @@ private:
         return args;
     }
 
-
-    // Return true if child is alive, false if not. If wait is true and child is alive, will wait forever for child to exit.
-    bool check_child(bool wait);
-    void start_collector();
-    void signal_collector(int signal);
-    bool is_auditd_present();
-    bool is_collector_alive();
-    void send_audit_pid_report(int pid);
-    bool is_auditd_enabled_systemd();
-    bool is_auditd_enabled_sysv();
-    bool is_auditd_enabled_upstart();
-
     Netlink _netlink;
     EventBuilder _builder;
-    std::string _auditd_path;
     std::string _collector_path;
     std::string _collector_config_path;
     Cmd _collector;
-    uint32_t _audit_pid;
     bool _pause_collector_check;
     std::chrono::steady_clock::time_point _pause_time;
     std::chrono::steady_clock::time_point _last_audit_pid_report;
     std::set<std::chrono::steady_clock::time_point> _collector_restarts;
 };
 
-
-#endif //AUOMS_COLLECTIONMONITOR_H
+#endif /* NETLINK_COLLECTIONMONITOR_H */

--- a/SystemMetrics.cpp
+++ b/SystemMetrics.cpp
@@ -18,6 +18,7 @@
 #include "Logger.h"
 #include "FileUtils.h"
 #include "StringUtils.h"
+#include "AuomsConfig.h"
 
 void SystemMetrics::run() {
     Logger::Info("SystemMetrics: starting");
@@ -53,7 +54,8 @@ bool read_proc_stat(uint64_t *cpu_user, uint64_t *cpu_user_nice, uint64_t *cpu_s
     *cpu_idle = 0;
     *num_cpu = 0;
     try {
-        auto lines = ReadFile("/proc/stat");
+        auto& proc_path = AuomsConfig::GetInstance().GetProcPath();
+        auto lines = ReadFile(proc_path + "/stat");
         if (lines.empty()) {
             return false;
         }
@@ -76,7 +78,8 @@ bool read_proc_stat(uint64_t *cpu_user, uint64_t *cpu_user_nice, uint64_t *cpu_s
 
 bool read_proc_meminfo(uint64_t *total_mem, uint64_t *free_mem) {
     try {
-        auto lines = ReadFile("/proc/meminfo");
+        auto& proc_path = AuomsConfig::GetInstance().GetProcPath();
+        auto lines = ReadFile(proc_path + "/meminfo");
         if (lines.empty()) {
             return false;
         }

--- a/auomscollect.cpp
+++ b/auomscollect.cpp
@@ -29,6 +29,7 @@
 #include "FileWatcher.h"
 #include "Defer.h"
 #include "Gate.h"
+#include "AuomsConfig.h"
 #include "FileUtils.h"
 #include "Metrics.h"
 #include "ProcMetrics.h"
@@ -219,7 +220,8 @@ bool DoNetlinkCollection(SPSCDataQueue& raw_queue, std::shared_ptr<Metric>& byte
     uint32_t pid = status.pid;
     uint32_t enabled = status.enabled;
 
-    if (pid != 0 && PathExists("/proc/" + std::to_string(pid))) {
+    auto& proc_path = AuomsConfig::GetInstance().GetProcPath();
+    if (pid != 0 && PathExists(proc_path + "/" + std::to_string(pid))) {
         Logger::Error("There is another process (pid = %d) already assigned as the audit collector", pid);
         return false;
     }

--- a/installer/conf/auoms.conf
+++ b/installer/conf/auoms.conf
@@ -6,6 +6,11 @@
 #
 #data_dir = /var/opt/microsoft/auoms
 
+# The path to the proc filesystem
+# Default is /proc. For containerized environments, this might be /host/proc
+#
+#proc_path = /proc
+
 # The directory where auoms places transient file like the input.socket file
 #
 #run_dir=/var/run/auoms


### PR DESCRIPTION
- Fix compilation on AzureLinux
- Path to proc can be overridden through config. When running in a container, this could be /host/proc.
- When configured to read events through the Kernel's netlink socket, don't look for auditd
- Define a class to hold the config variables. Makes it easier to override the value obtained from the config.